### PR TITLE
Add eslint settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "extends": "airbnb",
+    "plugins": [
+        "react"
+    ]
+};

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
         loader: 'babel-loader',
         query: {
           //added react-require to fix React is not defined issue
-          //did not work
+          //react-require must go before 'transform-runtime'
           plugins: ['react-require', 'transform-runtime'],
           presets: ['es2015', 'react']
         }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "unassuming-quasars",
   "dependencies": {
     "body-parser": "^1.15.0",
+    "eslint": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
     "express": "^4.13.4",
     "nodemon": "^1.9.1",
     "passport": "^0.3.2",
@@ -14,6 +16,8 @@
     "sequelize": "^3.21.0"
   },
   "devDependencies": {
+    "eslint-config-airbnb": "^7.0.0",
+    "eslint-plugin-react": "^4.3.0",
     "redux-devtools": "^3.2.0"
   }
 }


### PR DESCRIPTION
We should [setup](https://github.com/roadhump/SublimeLinter-eslint) a linter locally so that we can make sure to keep our style consistent. It'll be good practice for us! @jenjwong, I am not sure if there is an atom plugin for eslint but there might be.

Since I added new dependencies, make sure to:

```
npm install
```

again so that you download eslint locally. The above link will take you to the sublime text package that is needed for the linter settings to show up
